### PR TITLE
Remove unused variables to prevent compiler warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Probably the carriage return / line feed thing. Try this:
 perl -pli~ -e 's/^V^M//' Makefile* */Makefile useful/useful.h useful/useful.cpp qUAck/CmdIO.cpp qUAck/qUAck.h EDF/EDF.cpp EDF/EDFElement.[ch]* Conn/Conn.cpp
 ```
 
+Also check that you have installed all the dependencies (see list below).
+
 ### How do I configure it?
 
 Under Unix you can put configuration options in a .qUAckrc file in your home directory. Under Windows put them in a qUAck.edf file in the same directory as the executable. Here's an example:
@@ -92,6 +94,13 @@ Append the PID to the filename qUAck puts debug information into
 ### Backspace / delete / etc doesn't work in the editor (Unix)
 
 Your version of curses is broken :-)
+
+## Dependencies
+
+The following dependencies are required for compilation:
+
+ * OpenSSL headers - `libssl-dev` in Debian.
+ * ncurses headers - `libncurses5-dev` in Debian.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,80 +1,94 @@
-qUAck - Telnet look and feel client for UNaXcess II
-===================================================
+# qUAck - Telnet look and feel client for UNaXcess II
 
-FAQ
-===
+## FAQ
 
-*It doesn't compile*
+### It doesn't compile
+
 Probably the carriage return / line feed thing. Try this:
 
-`perl -pli~ -e 's/^V^M//' Makefile* */Makefile useful/useful.h useful/useful.cpp qUAck/CmdIO.cpp qUAck/qUAck.h EDF/EDF.cpp EDF/EDFElement.[ch]* Conn/Conn.cpp`
+```
+perl -pli~ -e 's/^V^M//' Makefile* */Makefile useful/useful.h useful/useful.cpp qUAck/CmdIO.cpp qUAck/qUAck.h EDF/EDF.cpp EDF/EDFElement.[ch]* Conn/Conn.cpp
+```
 
-*How do I configure it?*
+### How do I configure it?
+
 Under Unix you can put configuration options in a .qUAckrc file in your home directory. Under Windows put them in a qUAck.edf file in the same directory as the executable. Here's an example:
-   
-   <>
-     <server="localhost"/>
-     <port=4040/>
-     <username="sysop"/>
-   </>
-   
-   Other settings:
-   
-   <password="password"/>
-   
-   If you don't specify a password in the config file you will be prompted
-   for one
-   
-   <secure=1/>
-   <certificate="qUAck.pem"/>
-   
-   The certificate field is optional for secure connections
-   
-   <editor="/bin/vi"/>
-   
-   Use an external editor for text composition
-   
-   <browse=1/>
-   <browser="/usr/bin/netscape"/>
-   <browserwait=1/>
-   
-   Specify a browser for viewing URLs. browserwait tells qUAck to wait for
-   the launched browser to finish before carrying on (useful for terminal
-   stuff like lynx)
-   
-   <attachmentsize=n/>
-   <attachmentdir="/tmp"/>
-   
-   This sets the size of attachment you are prepared to recieved in a page.
-   By default no attachments will be sent to you. Use a setting of -1 for
-   any size. You can also specify a directory for saving attachments
-   
-   <busy=1/>
-   <silent=1/>
-   <shadow=1/>
-   
-   Login with busy / silent / shadow flag on (the ability to send and
-   recieve pages is diabled with shadow on)
-   
-   <thinpipe=1/>
-   
-   Use reduced data requests which refresh cached data (user list, folder
-   list) in case you're on a slow link
-   
-   <screensize=1/>
-   
-   Obey screen width / height settings stored on the server and ignore the
-   queried ones qUAck gets from your terminal
-   
-   <usepid=1/>
-   
-   Append the PID to the filename qUAck puts debug information into
-   
-*Backspace / delete / etc doesn't work in the editor (Unix)*
+
+```
+<>
+ <server="localhost"/>
+ <port=4040/>
+ <username="sysop"/>
+</>
+```
+
+Other settings:
+
+`<password="password"/>``
+
+If you don't specify a password in the config file you will be prompted for one
+
+```
+<secure=1/>
+<certificate="qUAck.pem"/>
+
+The certificate field is optional for secure connections
+
+`<editor="/bin/vi"/>``
+
+Use an external editor for text composition
+
+```
+<browse=1/>
+<browser="/usr/bin/netscape"/>
+<browserwait=1/>
+```
+
+Specify a browser for viewing URLs. browserwait tells qUAck to wait for the launched browser to finish before carrying on (useful for terminal stuff like lynx)
+
+```
+<attachmentsize=n/>
+<attachmentdir="/tmp"/>
+```
+
+This sets the size of attachment you are prepared to recieved in a page.
+By default no attachments will be sent to you. Use a setting of -1 for
+any size. You can also specify a directory for saving attachments
+
+```
+<busy=1/>
+<silent=1/>
+<shadow=1/>
+```
+
+Login with busy / silent / shadow flag on (the ability to send and
+recieve pages is diabled with shadow on)
+
+```
+<thinpipe=1/>
+```
+
+Use reduced data requests which refresh cached data (user list, folder
+list) in case you're on a slow link
+
+```
+<screensize=1/>
+```
+
+Obey screen width / height settings stored on the server and ignore the
+queried ones qUAck gets from your terminal
+
+```
+<usepid=1/>
+```
+
+Append the PID to the filename qUAck puts debug information into
+
+### Backspace / delete / etc doesn't work in the editor (Unix)
+
 Your version of curses is broken :-)
 
-Credits
-=======
+## Credits
 
 qUAck looks the way it does as a result of 10 years UI "refinement" beginning with old UNaXcess (circa 1984) and continuing until 1999 when we [the Manc CS UA bods] were dragged kicking and screaming onto UNaXcess II
 

--- a/README.md
+++ b/README.md
@@ -24,17 +24,22 @@ Under Unix you can put configuration options in a .qUAckrc file in your home dir
 
 Other settings:
 
-`<password="password"/>``
+```
+<password="password"/>
+```
 
 If you don't specify a password in the config file you will be prompted for one
 
 ```
 <secure=1/>
 <certificate="qUAck.pem"/>
+```
 
 The certificate field is optional for secure connections
 
-`<editor="/bin/vi"/>``
+```
+<editor="/bin/vi"/>
+```
 
 Use an external editor for text composition
 

--- a/qUAck/CmdMenu.cpp
+++ b/qUAck/CmdMenu.cpp
@@ -4511,7 +4511,7 @@ void FolderMenu(int iFolderID, int iMessageID, int iMsgPos)
 {
    STACKTRACE
    int iUserID = 0, iAccessLevel = LEVEL_NONE, iInitPos = 0, iVoteType = 0, iFromID = -1, iVoteID = 0;
-   int iAccessMode = FOLDERMODE_NORMAL, iStatus = LOGIN_OFF, iRetro = 0, iConfirm = 0, iMessageTop = 0, iValue = 0;
+   int iAccessMode = FOLDERMODE_NORMAL, iStatus = LOGIN_OFF, iRetro = 0, iConfirm = 0, iMessageTop = 0;
    bool bLoop = true, bAction = false, bRetro = false, bOldMenus = false, bValid = false;
    char cOption = '\0', szWrite[100], szFilename[100];
    char *szFolderName = NULL, *szOption = NULL, *szValue = NULL, *szUsername = NULL, *szFromName = NULL, *szSubject = NULL;

--- a/qUAck/CmdMenu.cpp
+++ b/qUAck/CmdMenu.cpp
@@ -9098,7 +9098,6 @@ void GameMenu()
    char cOption = '\0';
    char szWrite[200];
    char *szName = NULL, *szContentType = NULL;
-   CmdInput *pInput = NULL;
    EDF *pOptions = NULL;
    Game *pTemp = NULL;
 

--- a/qUAck/CmdMenu.cpp
+++ b/qUAck/CmdMenu.cpp
@@ -8874,7 +8874,7 @@ void MessageMenu()
 {
    int iMessageID = -1, iVoteType = 0;
    char cOption = '\0';
-   EDF *pRequest = NULL, *pReply = NULL, *pTemp = NULL, *pMessageIn, *pMessageOut = NULL;
+   EDF *pRequest = NULL, *pReply = NULL, *pTemp = NULL;
 
    while(cOption != 'j' && cOption != 'x')
    {

--- a/qUAck/CmdMenu.cpp
+++ b/qUAck/CmdMenu.cpp
@@ -2876,7 +2876,7 @@ char *URLToken(char **szString)
 int CmdURLList(const char *szString, int iContentNum, bool bDisplay, int iItemNum, char **szReturn)
 {
    int iAddressLen = 0;
-   char *szURL = NULL, *szWWW = NULL, *szAddress = NULL;
+   char *szURL = NULL, *szAddress = NULL;
 
    /* if(szString == NULL)
    {

--- a/qUAck/CmdMenu.cpp
+++ b/qUAck/CmdMenu.cpp
@@ -2875,7 +2875,6 @@ char *URLToken(char **szString)
 
 int CmdURLList(const char *szString, int iContentNum, bool bDisplay, int iItemNum, char **szReturn)
 {
-   bool bSlash = false;
    int iURLBack = 0, iAddressLen = 0;
    char *szURL = NULL, *szHTTP = NULL, *szWWW = NULL, *szAddress = NULL;
 
@@ -4016,7 +4015,7 @@ bool MessageMarkMenu(bool bAdd, int iFolderID, int iMessageID, int iFromID, cons
          iEndDate -= 60 * tmTime->tm_min;
          iEndDate -= tmTime->tm_sec;
          break;
-         
+
       case 'v':
          szRequest = MSG_MESSAGE_MARK_SAVE;
          break;

--- a/qUAck/CmdMenu.cpp
+++ b/qUAck/CmdMenu.cpp
@@ -2875,8 +2875,8 @@ char *URLToken(char **szString)
 
 int CmdURLList(const char *szString, int iContentNum, bool bDisplay, int iItemNum, char **szReturn)
 {
-   int iURLBack = 0, iAddressLen = 0;
-   char *szURL = NULL, *szHTTP = NULL, *szWWW = NULL, *szAddress = NULL;
+   int iAddressLen = 0;
+   char *szURL = NULL, *szWWW = NULL, *szAddress = NULL;
 
    /* if(szString == NULL)
    {

--- a/qUAck/CmdProcess.cpp
+++ b/qUAck/CmdProcess.cpp
@@ -511,7 +511,7 @@ bool CmdMessageAddFields(EDF *pRequest)
    int iFolderID = -1, iMsgType = 0, iToID = -1, iVoteEDF = 0, iDefTo = -1;
    int iMinValue = -1, iMaxValue = -1;
 	double dMinValue = 0, dMaxValue = 0;
-   char cVoteType = 'a', cVoteValues = 'f';
+   char cVoteValues = 'f';
    char *szOption = NULL, *szSubject = NULL, *szToName = NULL, *szUser = NULL;
    CmdInput *pInput = NULL;
    char cOption = '\0', cDefault = '\0';

--- a/qUAck/CmdShow.cpp
+++ b/qUAck/CmdShow.cpp
@@ -1276,7 +1276,7 @@ void CmdMessageTreeList(EDF *pReply, const char *szType, int iListType, int iLis
    int iAccessLevel = LEVEL_NONE, iNumTrees = 0, iSubscribed = 0, iReadOnly = 0, iRestricted = 0, iSubType = 0;
    int iTotalMsgs = 0, iTotalSize = 0, iTotalUnread = 0, iSearchType = 0, iFound = 0, iExpire = -1, iTreeID = 0;
    int iCurrUser = 0, iEditorID = 0, iNumCols = 0, iPriority = 0;
-   bool bRetro = false, bDevOption = false, bLoop = true, bDeleted = false;
+   bool bRetro = false, bDevOption = false, bLoop = true;
    char cSubType = '\0';
    char szWrite[100], szDepth[100];
    char szNumTypes[32];

--- a/qUAck/qUAck-unix.cpp
+++ b/qUAck/qUAck-unix.cpp
@@ -778,7 +778,6 @@ bool procstat(int iPID, int *iPPID, int *iSession)
 
 utmp *utmpscan(int iSession)
 {
-   int iTTYPos = 0;
    bool bFound = false;
    char *szTTY = NULL;
    struct utmp *pEntry = NULL;
@@ -795,19 +794,6 @@ utmp *utmpscan(int iSession)
          szTTY += 5;
       }
       debug(DEBUGLEVEL_INFO, "utmpscan device '%s'\n", szTTY);
-      /*
-      iTTYPos = strlen(szTTY);
-      if(iTTYPos > 0)
-      {
-         iTTYPos--;
-         while(iTTYPos > 0 && szTTY[iTTYPos] != '/')
-         {
-            iTTYPos--;
-         }
-         szTTY = szTTY + iTTYPos;
-         debug(DEBUGLEVEL_INFO, "utmpscan dev '%s'\n", szTTY);
-      }
-      */
    }
 
 #ifndef NetBSD

--- a/qUAck/qUAck.cpp
+++ b/qUAck/qUAck.cpp
@@ -1137,7 +1137,7 @@ bool CmdRequest(const char *szRequest, EDF *pRequest, bool bDelete, EDF **pReply
       debug(DEBUGLEVEL_ERR, "CmdRequest write failed\n");
       CmdShutdown("Unable to write request");
    }
-   
+
    lWrite = tickdiff(dWrite);
 
    m_bRequestWait = true;
@@ -1487,7 +1487,7 @@ int CmdLineName(const char *szType, const char *szTitle, CMDTABFUNC pTabFunc, ED
    {
       sprintf(szWrite, "%s (\0374%s\0370)", szWrite, RETRO_NAME(szMenu));
    }
-   
+
    if(szDefaultOp != NULL)
    {
       sprintf(szExtra, "RETURN %s", szDefaultOp);
@@ -1698,7 +1698,7 @@ int main(int argc, char **argv)
    int iArgNum = 0, iPort = 0, iTimeOff = -1, iBuildNum = 0, iAccessLevel = LEVEL_NONE, iFolderID = 0, iValue = 0, iSystemTime = 0, iAttachmentSize = 0;
    int iUserType = 0, iNumEdits = 0, iGiveUp = 10, iLoop = 0, iMsgMark = 0, iConfigHighlight = -1, iSubType = 0, iStatus = 0, iDebugLevel = DEBUGLEVEL_INFO;
    bool bSecure = false, bBusy = false, bSilent = false, bShadow = false, bLoop = false, bFolderCheck = true, bRetro = false, bUsePID = false, bLoggedIn = false, bMarkingField = false;
-   bool bNew = false, bBrowse = false, bBrowserWait = false;
+   bool bNew = false, bBrowserWait = false;
    double dTick = 0;
    char szWrite[200], szError[200];
    char *szConfig = NULL, *szServer = NULL, *szUsername = NULL, *szPassword = NULL, *szDebugDir = NULL, *szReply = NULL, *szName = NULL;


### PR DESCRIPTION
There are lots of unused variables which cause compiler warnings and this causes noise in the output which potentially masks other issues.